### PR TITLE
Add OpenAI chat example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -232,10 +232,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -481,10 +482,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1123,9 +1125,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -1133,6 +1135,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },

--- a/src/chat.html
+++ b/src/chat.html
@@ -1,0 +1,433 @@
+<!-- Source: https://github.com/casualwriter/vanilla-chatgpt -->
+<!DOCTYPE html>
+<head>
+  <title>Chat</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head>
+
+<style>
+body  { font-family: Roboto,Lato,Arial; line-height:1.5; font-size:16px; margin:0; padding:0; overflow:hidden; }
+header { background-color: rgb(31 41 55); }
+header { color:#eee; padding:12px; font-size:30px; height:45px; font-family:"Open Sans" }
+#left  { float:left;  width:calc(60vw - 30px); height:calc(100vh - 100px); }
+#right { float:right; width:40%; height:calc(100vh - 100px); } 
+#left, #prompt, #list { border:1px solid grey; }
+#left, #prompt, #list{ padding:6px; overflow:auto; }
+#list li:hover  { background:#ddd }
+#menu button    { font-family:Lato,arial; border-radius:3px; border:none; padding:3px 6px}
+#right textarea, #controls { display:block; width:96%; margin:3px auto;}
+#right textarea { background:#eee; box-sizing: border-box; }
+#controls { text-align:right; padding:5px 6px; border: 1px solid #fff; }
+#controls button { height: 28px; vertical-align: middle; }
+.prompt { color:#322; background:#ccc; padding:6px; }
+
+.markdown code { background:#f0f0f0; color:navy; border-radius:6px; padding:2px; } 
+.markdown pre  { background:#f0f0f0; margin:16px; border:1px solid #ddd; padding:8px; border-radius: 6px;  } 
+.markdown pre:hover button { display:block; }
+.markdown pre button { display:none; float:right; margin:4px }
+.markdown blockquote { background:#f0f0f0; border-left:6px solid grey; padding:8px }
+.markdown table { margin:12px; border-collapse: collapse; }
+.markdown th    { border:1px solid grey; background:lightgrey; padding:6px; } 
+.markdown td    { border:1px solid grey;  padding:6px; }
+.markdown tr:nth-child(even) {  background:#f0f0f0;  }
+
+@media print{
+  #menu, #right { display:none!important }
+  #left { position:relative; width:100%; left:0px; top:0px; border:none; height:auto; overflow:hidden }
+  .prompt { border-bottom: 1px solid grey }
+}
+
+@media screen and (max-width: 880px) {
+  #list, .desktop { display:none!important }
+  #right { position:absolute; width:auto; height:auto; bottom:10px; left:8px; right:70px }
+  #right textarea { height:3.2em; padding:10px; overflow:auto }
+  #left	 { width:97%; height:calc(100vh - 210px);  }
+}
+</style>
+
+<header>
+  <div id="heading" style="float:left">
+    Chat example
+  </div>
+</header>
+
+<div id="content" style="margin:8px;color:#112;background:bed">
+  <div id="right">
+    <textarea id="prompt" rows="10" placeholder="Please input prompt here..."></textarea>
+    <div id="controls">
+        <button onclick="chat.recognition()" title="voice input">🎤</button>
+        <button id="btnSend" accesskey="s" onclick="chat.submit()">Send</button>
+    </div>
+     <!--
+     <div id="list" style="height:calc(100vh - 163px)">
+        <b>Samples of prompt</b>
+        <ul>
+          <li>A quote of today</li>
+          <li>A table for 10 famous artists include name, DOB and style</li>
+          <li>Create an article outline in markdown format for "teamwork"</li>
+          <li>Create a dialogue discussing "the meaning of love"</li>
+          <li>Introduce "vanilla chatGPT"</li>
+          <li>Write a short story about "vanilla chatGPT"</li>
+          <li>Discuss about the pros and cons of "vanilla js"</li>
+          <li>Summarize the following content ...</li>
+        </ul>
+     </div>
+     -->
+  </div>
+  <div id="left">
+    <div id="main" style="padding:12px; max-width:960px">
+       <h3>
+        Conversation history 
+        <button onclick="chat.export()" title="export conversation">Export</button>
+       </h3>
+       
+       <!--
+       <p class="desktop">Please submit prompt by pressing 
+        <label><input type="radio" name="submitkey" onclick="chat.hotkey='enter'" checked>[Enter]</label>
+        <label><input type="radio" name="submitkey" onclick="chat.hotkey='ctrl'">[Ctrl-Enter]</label>
+       </p>
+       -->
+    </div>
+  </div>
+</div>
+
+<script>
+/*****************************************************************************
+ * casual-markdown - a lightweight regexp-base markdown parser with TOC support
+ * last updated on 2023/03/27, v0.91, some refinement for chatgpt markdown
+ *
+ * Copyright (c) 2022-2023, Casualwriter (MIT Licensed)
+ * https://github.com/casualwriter/casual-markdown
+*****************************************************************************/
+  // define md object, and extent function (which is a dummy function)
+  const md = { yaml:{}, before: function (str) {return str}, after: function (str) {return str} }
+
+  // function for REGEXP to convert html tag. ie. <TAG> => &lt;TAG*gt;  
+  md.formatTag = function (html) { return html.replace(/</g,'&lt;').replace(/\>/g,'&gt;'); }
+
+  //===== format code-block, highlight remarks/keywords for code/sql
+  md.formatCode = function (match, title, block) {
+    // convert tag <> to &lt; &gt; tab to 3 space, support marker using ^^^
+    block = block.replace(/</g,'&lt;').replace(/\>/g,'&gt;')
+    block = block.replace(/\t/g,'   ').replace(/\^\^\^(.+?)\^\^\^/g, '<mark>$1</mark>')
+    
+    // highlight comment and keyword based on title := none | sql | code
+    if (title.toLowerCase(title) == 'sql') {
+      block = block.replace(/^\-\-(.*)/gm,'<rem>--$1</rem>').replace(/\s\-\-(.*)/gm,' <rem>--$1</rem>')   
+      block = block.replace(/(\s?)(function|procedure|return|if|then|else|end|loop|while|or|and|case|when)(\s)/gim,'$1<b>$2</b>$3')
+      block = block.replace(/(\s?)(select|update|delete|insert|create|from|where|group by|having|set)(\s)/gim,'$1<b>$2</b>$3')
+    } else if ((title||'none')!=='none') {
+      block = block.replace(/^\/\/(.*)/gm,'<rem>//$1</rem>').replace(/\s\/\/(.*)/gm,' <rem>//$1</rem>')   
+      block = block.replace(/(\s?)(function|procedure|return|if|then|else|end|loop|while|or|and|case|when)(\s)/gim,'$1<b>$2</b>$3')
+      block = block.replace(/(\s?)(var|let|const|for|next|do|while|loop|continue|break|switch|try|catch|finally)(\s)/gim,'$1<b>$2</b>$3')
+    }
+    return '<pre title="' + title + '"><button onclick="md.clipboard(this)">copy</button><code>'  + block + '</code></pre>'
+  }
+  
+  //===== parse markdown string into HTML string (exclude code-block)
+  md.parser = function( mdstr ) {
+  
+    // apply yaml variables
+    for (var name in this.yaml) mdstr = mdstr.replace( new RegExp('\{\{\\s*'+name+'\\s*\}\}', 'gm'), this.yaml[name] )
+    
+    // table syntax
+    mdstr = mdstr.replace(/\n(.+?)\n.*?\-\-\s?\|\s?\-\-.*?\n([\s\S]*?)\n\s*?\n/g, function (m,p1,p2) {
+        var thead = p1.replace(/^\|(.+)/gm,'$1').replace(/(.+)\|$/gm,'$1').replace(/\|/g,'<th>')
+        var tbody = p2.replace(/^\|(.+)/gm,'$1').replace(/(.+)\|$/gm,'$1')
+        tbody = tbody.replace(/(.+)/gm,'<tr><td>$1</td></tr>').replace(/\|/g,'<td>')
+        return '\n<table>\n<thead>\n<th>' + thead + '\n</thead>\n<tbody>' + tbody + '\n</tbody></table>\n\n' 
+    } )   
+
+    // horizontal rule => <hr> 
+    mdstr = mdstr.replace(/^-{3,}|^\_{3,}|^\*{3,}$/gm, '<hr>').replace(/\n\n<hr\>/g, '\n<br><hr>')
+
+    // header => <h1>..<h5> 
+    mdstr = mdstr.replace(/^##### (.*?)\s*#*$/gm, '<h5>$1</h5>')
+              .replace(/^#### (.*?)\s*#*$/gm, '<h4>$1</h4>')
+              .replace(/^### (.*?)\s*#*$/gm, '<h3>$1</h3>')
+              .replace(/^## (.*?)\s*#*$/gm, '<h2>$1</h2>')
+              .replace(/^# (.*?)\s*#*$/gm, '<h1>$1</h1>')
+              .replace(/^<h(\d)\>(.*?)\s*{(.*)}\s*<\/h\d\>$/gm, '<h$1 id="$3">$2</h$1>')
+        
+    // inline code-block: `code-block` => <code>code-block</code>    
+    mdstr = mdstr.replace(/``(.*?)``/gm, function(m,p){ return '<code>' + md.formatTag(p).replace(/`/g,'&#96;') + '</code>'} ) 
+    mdstr = mdstr.replace(/`(.*?)`/gm, '<code>$1</code>' )
+        
+    // blockquote, max 2 levels => <blockquote>{text}</blockquote>
+    mdstr = mdstr.replace(/^\>\> (.*$)/gm, '<blockquote><blockquote>$1</blockquote></blockquote>')
+    mdstr = mdstr.replace(/^\> (.*$)/gm, '<blockquote>$1</blockquote>')
+    mdstr = mdstr.replace(/<\/blockquote\>\n<blockquote\>/g, '\n<br>' )
+    mdstr = mdstr.replace(/<\/blockquote\>\n<br\><blockquote\>/g, '\n<br>' )
+                  
+    // image syntax: ![title](url) => <img alt="title" src="url" />          
+    mdstr = mdstr.replace(/!\[(.*?)\]\((.*?) "(.*?)"\)/gm, '<img alt="$1" src="$2" $3 />')
+    mdstr = mdstr.replace(/!\[(.*?)\]\((.*?)\)/gm, '<img alt="$1" src="$2" width="90%" />')
+                  
+    // links syntax: [title "title"](url) => <a href="url" title="title">text</a>          
+    mdstr = mdstr.replace(/\[(.*?)\]\((.*?) "new"\)/gm, '<a href="$2" target=_new>$1</a>')
+    mdstr = mdstr.replace(/\[(.*?)\]\((.*?) "(.*?)"\)/gm, '<a href="$2" title="$3">$1</a>')
+    mdstr = mdstr.replace(/([<\s])(https?\:\/\/.*?)([\s\>])/gm, '$1<a href="$2">$2</a>$3')
+    mdstr = mdstr.replace(/\[(.*?)\]\(\)/gm, '<a href="$1">$1</a>')
+    mdstr = mdstr.replace(/\[(.*?)\]\((.*?)\)/gm, '<a href="$2">$1</a>')
+                  
+    // unordered/ordered list, max 2 levels  => <ul><li>..</li></ul>, <ol><li>..</li></ol>
+    mdstr = mdstr.replace(/^[\*+-][ .](.*)/gm, '<ul><li>$1</li></ul>' )
+    mdstr = mdstr.replace(/^\d\d?[ .](.*)/gm, '<ol><li>$1</li></ol>' )
+    mdstr = mdstr.replace(/^\s{2,6}[\*+-][ .](.*)/gm, '<ul><ul><li>$1</li></ul></ul>' )
+    mdstr = mdstr.replace(/^\s{2,6}\d[ .](.*)/gm, '<ul><ol><li>$1</li></ol></ul>' )
+    mdstr = mdstr.replace(/<\/[ou]l\>\n\n?<[ou]l\>/g, '\n' )
+    mdstr = mdstr.replace(/<\/[ou]l\>\n<[ou]l\>/g, '\n' )
+                  
+    // text decoration: bold, italic, underline, strikethrough, highlight                
+    mdstr = mdstr.replace(/\*\*\*(\w.*?[^\\])\*\*\*/gm, '<b><em>$1</em></b>')
+    mdstr = mdstr.replace(/\*\*(\w.*?[^\\])\*\*/gm, '<b>$1</b>')
+    mdstr = mdstr.replace(/\*(\w.*?[^\\])\*/gm, '<em>$1</em>')
+    mdstr = mdstr.replace(/___(\w.*?[^\\])___/gm, '<b><em>$1</em></b>')
+    mdstr = mdstr.replace(/__(\w.*?[^\\])__/gm, '<u>$1</u>')
+    // mdstr = mdstr.replace(/_(\w.*?[^\\])_/gm, '<u>$1</u>')  // NOT support!! 
+    mdstr = mdstr.replace(/\^\^\^(.+?)\^\^\^/gm, '<mark>$1</mark>')
+    mdstr = mdstr.replace(/\^\^(\w.*?)\^\^/gm, '<ins>$1</ins>')
+    mdstr = mdstr.replace(/~~(\w.*?)~~/gm, '<del>$1</del>')
+                  
+    // line break and paragraph => <br/> <p>                
+    mdstr = mdstr.replace(/  \n/g, '\n<br/>').replace(/\n\s*\n/g, '\n<p>\n')
+        
+    // indent as code-block          
+    mdstr = mdstr.replace(/^ {4,10}(.*)/gm, function(m,p) { return '<pre><code>' + md.formatTag(p) + '</code></pre>'} )
+    mdstr = mdstr.replace(/^\t(.*)/gm, function(m,p) { return '<pre><code>' + md.formatTag(p) + '</code></pre>'} )
+    mdstr = mdstr.replace(/<\/code\><\/pre\>\n<pre\><code\>/g, '\n' )
+
+    // Escaping Characters                
+    return mdstr.replace(/\\([`_~\*\+\-\.\^\\\<\>\(\)\[\]])/gm, '$1' )
+  }
+
+  //===== parse markdown string into HTML content (cater code-block)
+  md.html = function (mdText) { 
+    // replace \r\n to \n, and handle front matter for simple YAML
+    mdText = mdText.replace(/\r\n/g, '\n').replace( /^---+\s*\n([\s\S]*?)\n---+\s*\n/, md.formatYAML )
+    // handle code-block.
+    mdText = mdText.replace(/\n~~~/g,'\n```').replace(/\n``` *(.*?)\n([\s\S]*?)\n``` *\n/g, md.formatCode)
+    
+    // split by "<code>", skip for code-block and process normal text
+    var pos1=0, pos2=0, mdHTML = ''
+    while ( (pos1 = mdText.indexOf('<code>')) >= 0 ) {
+      pos2 = mdText.indexOf('</code>', pos1 )
+      mdHTML += md.after( md.parser( md.before( mdText.substr(0,pos1) ) ) )
+      mdHTML += mdText.substr(pos1, (pos2>0? pos2-pos1+7 : mdtext.length) )
+      mdText = mdText.substr( pos2 + 7 )
+    }
+
+    return '<div class="markdown">' + mdHTML + md.after( md.parser( md.before(mdText) ) ) + '</div>'
+  }
+  
+  md.clipboard = (e) => {
+    navigator.clipboard.writeText( e.parentNode.innerText.replace('copy\n','') )
+    e.innerText = 'copied'
+  }
+//============= end of casual-markdown-parser===================
+
+/*****************************************************************************
+* vanilla-chatgpt.js - chat library for openai-chatgpt
+* last updated on 2023/03/28, v0.60, basic chat, responsive, print-friendly, export.
+*
+* Copyright (c) 2023, Casualwriter (MIT Licensed)
+* https://github.com/casualwriter/vanilla-chatgpt
+*****************************************************************************/
+
+const chat = (id) => window.document.getElementById(id);
+
+// Set the API endpoint URL
+chat.endPoint  = "/chat";
+chat.model = "gpt-3.5-turbo"
+chat.body  = { /*model: chat.model, temperature: 0.8*/ }
+chat.history = []
+
+// stream result from openai
+chat.stream = function (prompt) {
+
+  //chat.body.stream = true 
+  chat.body.messages = [ { role: "user", content: prompt} ]
+  chat.headers = { "Content-Type": "application/json" }
+  chat.result = ''
+  chat.controller = new AbortController();
+  const signal = chat.controller.signal
+   
+  for (let i=chat.history.length-1; i>=0&&i>(chat.history.length-3); i--) {
+    chat.body.messages.unshift( { role:'assistant', content: chat.history[i].result } );
+    chat.body.messages.unshift( { role:'user', content: chat.history[i].prompt } );
+  }
+  
+  fetch( chat.endPoint, { method:'POST', headers: chat.headers, body: JSON.stringify(chat.body), signal } )
+  .then( response => { 
+  
+    if (!response.ok) {
+        if (response.status == 401) throw new Error('401 Unauthorized, invalide API Key');
+        throw new Error('failed to get data, error status '+response.status)
+    }
+    
+    const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
+    
+    reader.read().then( function processText({ done, value }) {
+    
+      if (done) return chat.oncomplete(chat.result);
+      
+      const lines = (chat.value=value).split('\n');
+
+      for (let i in lines) {
+        if (lines[i].length === 0) continue;     // ignore empty message
+        if (lines[i].startsWith(':')) continue;  // ignore comment message
+        if (lines[i] === 'data: [DONE]') return chat.oncomplete(chat.result); // end of message
+        
+        chat.json = JSON.parse(lines[i].substring(6));
+        if (chat.json.choices) {
+          chat.result += (chat.json.choices[0].delta.content||'') 
+        }	 
+      }
+
+      chat.onmessage(chat.result)
+      return reader.read().then(processText);
+       
+    } )
+    
+  } ).catch( error => chat.onerror(error) );
+  
+}
+
+// default error handle
+chat.onerror = (error) => { alert(error);  };
+
+// export conversation
+chat.export = (fname) => {
+  if (!chat.history || chat.history.length === 0) {
+    alert('No conversation to export!');
+    return;
+}
+  const link = document.createElement('a');
+  link.href = 'data:text/plain;charset=utf-8,' 
+  chat.history.forEach( (x) => { 
+    link.href += encodeURIComponent('### '+x.prompt+'\n\n'+x.result+'\n\n') 
+  } );  
+  link.download = fname||('chat-'+new Date().toISOString().substr(0,16))+'.md';
+  link.click();
+} 
+
+//================= main program ===================
+// display result when receiving message
+chat.onmessage = function (text) {
+  chat("message").innerHTML = 'receiving messages..'
+  chat("receiving").innerHTML = md.html(text + '<br><br>');
+}
+
+// show whole conversation when message completed
+chat.oncomplete = (text) => {
+  let html1='', html2=''
+  chat("message").innerHTML = `(model: ${chat.model})`
+  chat.history.push( { prompt: chat.prompt, result: chat.result } )
+  
+  for (let i=0; i<chat.history.length; i++) {
+     html1 += '<h4 class=prompt id=prompt'+i+' ondblclick="chat.clipboard('+i+')" title="doubleclick to copy">' 
+     html1 += chat.history[i].prompt + '</h4>\n' + chat.history[i].result + '\n\n'
+     html2 += '<li onclick="location=this.title" title="#prompt' + i + '">' + chat.history[i].prompt
+  }
+  
+  html1 += '<div><button style="float:left" onclick="chat.redo()">Redo</button>'
+  html1 += '<button style="float:right" onclick="chat.speak()">🔊 speak</button>'
+  
+  chat("main").innerHTML = md.html(html1) + '<br></div>'
+  chat("list").innerHTML = html2
+  chat("left").scrollTop = chat("left").scrollHeight;
+  chat("btnSend").innerHTML = '<b>S</b>end'
+  
+  if (document.body.clientWidth > 800) {
+    chat('prompt').select()
+    chat('prompt').focus();
+  } else {
+    chat('prompt').value = ''
+  }  
+}
+
+// abort fetch request.
+chat.abort = () => { 
+  chat.controller.abort()
+  chat("receiving").innerHTML += '\n<font color=red>Message Aborted!</font>'
+  chat("receiving").id = 'abort';
+};
+
+// submit prompt
+chat.submit = () => {
+  if (chat("btnSend").innerText === 'Stop..') {
+    chat.abort()
+    chat("btnSend").innerText = 'Send'
+  } else {
+    chat.stream( chat.prompt = chat('prompt').value )
+    chat("main").innerHTML += '<h4 class=prompt>' + chat.prompt + '</h4>\n<div id=receiving>Receiving....</div>'
+    chat("left").scrollTop = chat("left").scrollHeight;
+    chat("btnSend").innerText = 'Stop..'
+  }  
+}
+
+/*
+// show default prompt list
+chat.showPrompts = () => {
+  chat('list').innerHTML = chat.prompts
+  document.querySelectorAll('#list li').forEach( (element) => {
+    element.addEventListener('click', (event) => {
+      chat('prompt').value = element.innerText
+      chat('prompt').focus();
+    });
+  })
+};
+*/
+
+chat.clipboard = (i) => {
+  navigator.clipboard.writeText( '### '+ chat.history[i].prompt + '\n\n' + chat.history[i].result )
+  chat("message").innerText = 'dialogue has been copied to clipboard'
+}
+
+// prompt for API key if not found in localStorage
+window.onload = () => {
+  // chat.prompts = chat('list').innerHTML
+  // chat.showPrompts()
+  chat('prompt').focus();
+}
+
+// add submit hot-key of ctrl-enter
+document.addEventListener('keydown', function(event) {
+  if ( event.key==='Enter' && (chat.hotkey!='ctrl'||event.ctrlKey)) {
+    if (chat("btnSend").innerText === 'Send') { 
+      event.preventDefault(); chat.submit(); 
+    }
+  }  
+});
+
+// [20230412] redo. submit latest prompt
+chat.redo = () => {
+  chat.history.pop()
+  chat('prompt').value = chat.prompt
+  chat.submit()
+}
+
+// speak the latest answer
+chat.speak = (i)  => {
+  if (window.speechSynthesis.speaking) {
+     window.speechSynthesis.cancel();
+  } else {
+    i = ( i>=0? i : chat.history.length-1 )
+    const utterance = new SpeechSynthesisUtterance(chat.history[i].result);
+    utterance.rate = 1.5;
+    window.speechSynthesis.speak(utterance);
+  }
+}
+
+// voice recognition
+var SpeechRecognition = SpeechRecognition || webkitSpeechRecognition;
+chat.speech = new SpeechRecognition();
+
+chat.speech.onresult = e => chat('prompt').value = e.results[0][0].transcript;
+
+chat.recognition = () => {
+  chat.speech.start()
+  chat('prompt').value = 'Listening...'
+}   
+</script>

--- a/src/chat.html
+++ b/src/chat.html
@@ -74,148 +74,7 @@ header { color:#eee; padding:12px; font-size:30px; height:45px; font-family:"Ope
   </div>
 </div>
 
-<script>
-/*****************************************************************************
- * casual-markdown - a lightweight regexp-base markdown parser with TOC support
- * last updated on 2023/03/27, v0.91, some refinement for chatgpt markdown
- *
- * Copyright (c) 2022-2023, Casualwriter (MIT Licensed)
- * https://github.com/casualwriter/casual-markdown
-*****************************************************************************/
-  // define md object, and extent function (which is a dummy function)
-  const md = { yaml:{}, before: function (str) {return str}, after: function (str) {return str} }
-
-  // function for REGEXP to convert html tag. ie. <TAG> => &lt;TAG*gt;  
-  md.formatTag = function (html) { return html.replace(/</g,'&lt;').replace(/\>/g,'&gt;'); }
-
-  //===== format code-block, highlight remarks/keywords for code/sql
-  md.formatCode = function (match, title, block) {
-    // convert tag <> to &lt; &gt; tab to 3 space, support marker using ^^^
-    block = block.replace(/</g,'&lt;').replace(/\>/g,'&gt;')
-    block = block.replace(/\t/g,'   ').replace(/\^\^\^(.+?)\^\^\^/g, '<mark>$1</mark>')
-    
-    // highlight comment and keyword based on title := none | sql | code
-    if (title.toLowerCase(title) == 'sql') {
-      block = block.replace(/^\-\-(.*)/gm,'<rem>--$1</rem>').replace(/\s\-\-(.*)/gm,' <rem>--$1</rem>')   
-      block = block.replace(/(\s?)(function|procedure|return|if|then|else|end|loop|while|or|and|case|when)(\s)/gim,'$1<b>$2</b>$3')
-      block = block.replace(/(\s?)(select|update|delete|insert|create|from|where|group by|having|set)(\s)/gim,'$1<b>$2</b>$3')
-    } else if ((title||'none')!=='none') {
-      block = block.replace(/^\/\/(.*)/gm,'<rem>//$1</rem>').replace(/\s\/\/(.*)/gm,' <rem>//$1</rem>')   
-      block = block.replace(/(\s?)(function|procedure|return|if|then|else|end|loop|while|or|and|case|when)(\s)/gim,'$1<b>$2</b>$3')
-      block = block.replace(/(\s?)(var|let|const|for|next|do|while|loop|continue|break|switch|try|catch|finally)(\s)/gim,'$1<b>$2</b>$3')
-    }
-    return '<pre title="' + title + '"><button onclick="md.clipboard(this)">copy</button><code>'  + block + '</code></pre>'
-  }
-  
-  //===== parse markdown string into HTML string (exclude code-block)
-  md.parser = function( mdstr ) {
-  
-    // apply yaml variables
-    for (var name in this.yaml) mdstr = mdstr.replace( new RegExp('\{\{\\s*'+name+'\\s*\}\}', 'gm'), this.yaml[name] )
-    
-    // table syntax
-    mdstr = mdstr.replace(/\n(.+?)\n.*?\-\-\s?\|\s?\-\-.*?\n([\s\S]*?)\n\s*?\n/g, function (m,p1,p2) {
-        var thead = p1.replace(/^\|(.+)/gm,'$1').replace(/(.+)\|$/gm,'$1').replace(/\|/g,'<th>')
-        var tbody = p2.replace(/^\|(.+)/gm,'$1').replace(/(.+)\|$/gm,'$1')
-        tbody = tbody.replace(/(.+)/gm,'<tr><td>$1</td></tr>').replace(/\|/g,'<td>')
-        return '\n<table>\n<thead>\n<th>' + thead + '\n</thead>\n<tbody>' + tbody + '\n</tbody></table>\n\n' 
-    } )   
-
-    // horizontal rule => <hr> 
-    mdstr = mdstr.replace(/^-{3,}|^\_{3,}|^\*{3,}$/gm, '<hr>').replace(/\n\n<hr\>/g, '\n<br><hr>')
-
-    // header => <h1>..<h5> 
-    mdstr = mdstr.replace(/^##### (.*?)\s*#*$/gm, '<h5>$1</h5>')
-              .replace(/^#### (.*?)\s*#*$/gm, '<h4>$1</h4>')
-              .replace(/^### (.*?)\s*#*$/gm, '<h3>$1</h3>')
-              .replace(/^## (.*?)\s*#*$/gm, '<h2>$1</h2>')
-              .replace(/^# (.*?)\s*#*$/gm, '<h1>$1</h1>')
-              .replace(/^<h(\d)\>(.*?)\s*{(.*)}\s*<\/h\d\>$/gm, '<h$1 id="$3">$2</h$1>')
-        
-    // inline code-block: `code-block` => <code>code-block</code>    
-    mdstr = mdstr.replace(/``(.*?)``/gm, function(m,p){ return '<code>' + md.formatTag(p).replace(/`/g,'&#96;') + '</code>'} ) 
-    mdstr = mdstr.replace(/`(.*?)`/gm, '<code>$1</code>' )
-        
-    // blockquote, max 2 levels => <blockquote>{text}</blockquote>
-    mdstr = mdstr.replace(/^\>\> (.*$)/gm, '<blockquote><blockquote>$1</blockquote></blockquote>')
-    mdstr = mdstr.replace(/^\> (.*$)/gm, '<blockquote>$1</blockquote>')
-    mdstr = mdstr.replace(/<\/blockquote\>\n<blockquote\>/g, '\n<br>' )
-    mdstr = mdstr.replace(/<\/blockquote\>\n<br\><blockquote\>/g, '\n<br>' )
-                  
-    // image syntax: ![title](url) => <img alt="title" src="url" />          
-    mdstr = mdstr.replace(/!\[(.*?)\]\((.*?) "(.*?)"\)/gm, '<img alt="$1" src="$2" $3 />')
-    mdstr = mdstr.replace(/!\[(.*?)\]\((.*?)\)/gm, '<img alt="$1" src="$2" width="90%" />')
-                  
-    // links syntax: [title "title"](url) => <a href="url" title="title">text</a>          
-    mdstr = mdstr.replace(/\[(.*?)\]\((.*?) "new"\)/gm, '<a href="$2" target=_new>$1</a>')
-    mdstr = mdstr.replace(/\[(.*?)\]\((.*?) "(.*?)"\)/gm, '<a href="$2" title="$3">$1</a>')
-    mdstr = mdstr.replace(/([<\s])(https?\:\/\/.*?)([\s\>])/gm, '$1<a href="$2">$2</a>$3')
-    mdstr = mdstr.replace(/\[(.*?)\]\(\)/gm, '<a href="$1">$1</a>')
-    mdstr = mdstr.replace(/\[(.*?)\]\((.*?)\)/gm, '<a href="$2">$1</a>')
-                  
-    // unordered/ordered list, max 2 levels  => <ul><li>..</li></ul>, <ol><li>..</li></ol>
-    mdstr = mdstr.replace(/^[\*+-][ .](.*)/gm, '<ul><li>$1</li></ul>' )
-    mdstr = mdstr.replace(/^\d\d?[ .](.*)/gm, '<ol><li>$1</li></ol>' )
-    mdstr = mdstr.replace(/^\s{2,6}[\*+-][ .](.*)/gm, '<ul><ul><li>$1</li></ul></ul>' )
-    mdstr = mdstr.replace(/^\s{2,6}\d[ .](.*)/gm, '<ul><ol><li>$1</li></ol></ul>' )
-    mdstr = mdstr.replace(/<\/[ou]l\>\n\n?<[ou]l\>/g, '\n' )
-    mdstr = mdstr.replace(/<\/[ou]l\>\n<[ou]l\>/g, '\n' )
-                  
-    // text decoration: bold, italic, underline, strikethrough, highlight                
-    mdstr = mdstr.replace(/\*\*\*(\w.*?[^\\])\*\*\*/gm, '<b><em>$1</em></b>')
-    mdstr = mdstr.replace(/\*\*(\w.*?[^\\])\*\*/gm, '<b>$1</b>')
-    mdstr = mdstr.replace(/\*(\w.*?[^\\])\*/gm, '<em>$1</em>')
-    mdstr = mdstr.replace(/___(\w.*?[^\\])___/gm, '<b><em>$1</em></b>')
-    mdstr = mdstr.replace(/__(\w.*?[^\\])__/gm, '<u>$1</u>')
-    // mdstr = mdstr.replace(/_(\w.*?[^\\])_/gm, '<u>$1</u>')  // NOT support!! 
-    mdstr = mdstr.replace(/\^\^\^(.+?)\^\^\^/gm, '<mark>$1</mark>')
-    mdstr = mdstr.replace(/\^\^(\w.*?)\^\^/gm, '<ins>$1</ins>')
-    mdstr = mdstr.replace(/~~(\w.*?)~~/gm, '<del>$1</del>')
-                  
-    // line break and paragraph => <br/> <p>                
-    mdstr = mdstr.replace(/  \n/g, '\n<br/>').replace(/\n\s*\n/g, '\n<p>\n')
-        
-    // indent as code-block          
-    mdstr = mdstr.replace(/^ {4,10}(.*)/gm, function(m,p) { return '<pre><code>' + md.formatTag(p) + '</code></pre>'} )
-    mdstr = mdstr.replace(/^\t(.*)/gm, function(m,p) { return '<pre><code>' + md.formatTag(p) + '</code></pre>'} )
-    mdstr = mdstr.replace(/<\/code\><\/pre\>\n<pre\><code\>/g, '\n' )
-
-    // Escaping Characters                
-    return mdstr.replace(/\\([`_~\*\+\-\.\^\\\<\>\(\)\[\]])/gm, '$1' )
-  }
-
-  //===== parse markdown string into HTML content (cater code-block)
-  md.html = function (mdText) { 
-    // replace \r\n to \n, and handle front matter for simple YAML
-    mdText = mdText.replace(/\r\n/g, '\n').replace( /^---+\s*\n([\s\S]*?)\n---+\s*\n/, md.formatYAML )
-    // handle code-block.
-    mdText = mdText.replace(/\n~~~/g,'\n```').replace(/\n``` *(.*?)\n([\s\S]*?)\n``` *\n/g, md.formatCode)
-    
-    // split by "<code>", skip for code-block and process normal text
-    var pos1=0, pos2=0, mdHTML = ''
-    while ( (pos1 = mdText.indexOf('<code>')) >= 0 ) {
-      pos2 = mdText.indexOf('</code>', pos1 )
-      mdHTML += md.after( md.parser( md.before( mdText.substr(0,pos1) ) ) )
-      mdHTML += mdText.substr(pos1, (pos2>0? pos2-pos1+7 : mdtext.length) )
-      mdText = mdText.substr( pos2 + 7 )
-    }
-
-    return '<div class="markdown">' + mdHTML + md.after( md.parser( md.before(mdText) ) ) + '</div>'
-  }
-  
-  md.clipboard = (e) => {
-    navigator.clipboard.writeText( e.parentNode.innerText.replace('copy\n','') )
-    e.innerText = 'copied'
-  }
-//============= end of casual-markdown-parser===================
-
-/*****************************************************************************
-* vanilla-chatgpt.js - chat library for openai-chatgpt
-* last updated on 2023/03/28, v0.60, basic chat, responsive, print-friendly, export.
-*
-* Copyright (c) 2023, Casualwriter (MIT Licensed)
-* https://github.com/casualwriter/vanilla-chatgpt
-*****************************************************************************/
+<script type="text/javascript">
 
 const chat = (id) => window.document.getElementById(id);
 
@@ -309,11 +168,6 @@ chat.export = (fname) => {
 } 
 
 //================= main program ===================
-// display result when receiving message
-chat.onmessage = function (text) {
-  chat("message").innerHTML = 'receiving messages..';
-  chat("receiving").innerHTML = md.html(text + '<br><br>');
-}
 
 // show whole conversation when message completed
 chat.oncomplete = (text) => {
@@ -323,10 +177,10 @@ chat.oncomplete = (text) => {
   
   for (let i=0; i < chat.history.length; i++) {
      html += '<h4 class="prompt" id="prompt'+i+'">'; 
-     html += chat.history[i].prompt + '</h4>\n' + chat.history[i].result + '\n\n';
+     html += chat.history[i].prompt + '</h4><div class="result">' + chat.history[i].result + '</div>';
   }
   
-  chat("main").innerHTML = md.html(html) + '<br></div>'
+  chat("main").innerHTML = html;
   chat("left").scrollTop = chat("left").scrollHeight;
   chat("btnSend").innerHTML = 'Send'
   

--- a/src/chat.html
+++ b/src/chat.html
@@ -253,12 +253,11 @@ chat.stream = function (prompt) {
     }
 
     // this is for non-streaming response
-    const jsonBody = response.json();
-    // const jsonBody = JSON.parse('{"role":"assistant","content":"Ok"}'); // fake response for testing
-    chat.result = (jsonBody.content || '');
-    chat.oncomplete(chat.result);
-    chat("message").innerHTML = 'Done.';
-
+    response.json().then( jsonBody => {
+        chat.result = (jsonBody.content || '');
+        chat.oncomplete(chat.result);
+        chat("message").innerHTML = 'Done.';
+    }).catch( error => chat.onerror(error) );
     
     /*
     // this is for streaming response (not supported yet)

--- a/src/chat.html
+++ b/src/chat.html
@@ -20,6 +20,8 @@ header { color:#eee; padding:12px; font-size:30px; height:45px; font-family:"Ope
 #right textarea { background:#eee; box-sizing: border-box; }
 #controls { text-align:right; padding:5px 6px; border: 1px solid #fff; }
 #controls button { height: 28px; vertical-align: middle; }
+#message { float: left; }
+#mail, #title { padding:12px; max-width:960px; }
 .prompt { color:#322; background:#ccc; padding:6px; }
 
 .markdown code { background:#f0f0f0; color:navy; border-radius:6px; padding:2px; } 
@@ -56,38 +58,18 @@ header { color:#eee; padding:12px; font-size:30px; height:45px; font-family:"Ope
   <div id="right">
     <textarea id="prompt" rows="10" placeholder="Please input prompt here..."></textarea>
     <div id="controls">
+        <span id="message"><!-- will be filled with status messages --></span>
         <button onclick="chat.recognition()" title="voice input">🎤</button>
         <button id="btnSend" accesskey="s" onclick="chat.submit()">Send</button>
     </div>
-     <!--
-     <div id="list" style="height:calc(100vh - 163px)">
-        <b>Samples of prompt</b>
-        <ul>
-          <li>A quote of today</li>
-          <li>A table for 10 famous artists include name, DOB and style</li>
-          <li>Create an article outline in markdown format for "teamwork"</li>
-          <li>Create a dialogue discussing "the meaning of love"</li>
-          <li>Introduce "vanilla chatGPT"</li>
-          <li>Write a short story about "vanilla chatGPT"</li>
-          <li>Discuss about the pros and cons of "vanilla js"</li>
-          <li>Summarize the following content ...</li>
-        </ul>
-     </div>
-     -->
   </div>
   <div id="left">
-    <div id="main" style="padding:12px; max-width:960px">
-       <h3>
+    <h3 id="title">
         Conversation history 
         <button onclick="chat.export()" title="export conversation">Export</button>
-       </h3>
-       
-       <!--
-       <p class="desktop">Please submit prompt by pressing 
-        <label><input type="radio" name="submitkey" onclick="chat.hotkey='enter'" checked>[Enter]</label>
-        <label><input type="radio" name="submitkey" onclick="chat.hotkey='ctrl'">[Ctrl-Enter]</label>
-       </p>
-       -->
+    </h3>
+    <div id="main">
+    <!-- conversation history will be displayed here -->
     </div>
   </div>
 </div>
@@ -247,25 +229,39 @@ chat.history = []
 chat.stream = function (prompt) {
 
   //chat.body.stream = true 
-  chat.body.messages = [ { role: "user", content: prompt} ]
-  chat.headers = { "Content-Type": "application/json" }
-  chat.result = ''
+  chat.body.messages = [ { role: "user", content: prompt} ];
+  chat.result = '';
   chat.controller = new AbortController();
-  const signal = chat.controller.signal
+  const signal = chat.controller.signal;
    
-  for (let i=chat.history.length-1; i>=0&&i>(chat.history.length-3); i--) {
+  // if there is history, add the last 5 messages to the chat body
+  for (let i=chat.history.length-1; i>=0 && i > (chat.history.length - 5); i--) {
     chat.body.messages.unshift( { role:'assistant', content: chat.history[i].result } );
     chat.body.messages.unshift( { role:'user', content: chat.history[i].prompt } );
   }
   
-  fetch( chat.endPoint, { method:'POST', headers: chat.headers, body: JSON.stringify(chat.body), signal } )
-  .then( response => { 
+  fetch( chat.endPoint, {
+    method:'POST',
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(chat.body),
+    signal
+  }).then( response => { 
   
     if (!response.ok) {
         if (response.status == 401) throw new Error('401 Unauthorized, invalide API Key');
         throw new Error('failed to get data, error status '+response.status)
     }
+
+    // this is for non-streaming response
+    const jsonBody = response.json();
+    // const jsonBody = JSON.parse('{"role":"assistant","content":"Ok"}'); // fake response for testing
+    chat.result = (jsonBody.content || '');
+    chat.oncomplete(chat.result);
+    chat("message").innerHTML = 'Done.';
+
     
+    /*
+    // this is for streaming response (not supported yet)
     const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
     
     reader.read().then( function processText({ done, value }) {
@@ -289,6 +285,7 @@ chat.stream = function (prompt) {
       return reader.read().then(processText);
        
     } )
+      */
     
   } ).catch( error => chat.onerror(error) );
   
@@ -300,7 +297,7 @@ chat.onerror = (error) => { alert(error);  };
 // export conversation
 chat.export = (fname) => {
   if (!chat.history || chat.history.length === 0) {
-    alert('No conversation to export!');
+    chat("message").innerHTML = 'No conversation to export!'
     return;
 }
   const link = document.createElement('a');
@@ -315,36 +312,26 @@ chat.export = (fname) => {
 //================= main program ===================
 // display result when receiving message
 chat.onmessage = function (text) {
-  chat("message").innerHTML = 'receiving messages..'
+  chat("message").innerHTML = 'receiving messages..';
   chat("receiving").innerHTML = md.html(text + '<br><br>');
 }
 
 // show whole conversation when message completed
 chat.oncomplete = (text) => {
-  let html1='', html2=''
-  chat("message").innerHTML = `(model: ${chat.model})`
+  let html='';
+  // chat("message").innerHTML = `(model: ${chat.model})`
   chat.history.push( { prompt: chat.prompt, result: chat.result } )
   
-  for (let i=0; i<chat.history.length; i++) {
-     html1 += '<h4 class=prompt id=prompt'+i+' ondblclick="chat.clipboard('+i+')" title="doubleclick to copy">' 
-     html1 += chat.history[i].prompt + '</h4>\n' + chat.history[i].result + '\n\n'
-     html2 += '<li onclick="location=this.title" title="#prompt' + i + '">' + chat.history[i].prompt
+  for (let i=0; i < chat.history.length; i++) {
+     html += '<h4 class="prompt" id="prompt'+i+'">'; 
+     html += chat.history[i].prompt + '</h4>\n' + chat.history[i].result + '\n\n';
   }
   
-  html1 += '<div><button style="float:left" onclick="chat.redo()">Redo</button>'
-  html1 += '<button style="float:right" onclick="chat.speak()">🔊 speak</button>'
-  
-  chat("main").innerHTML = md.html(html1) + '<br></div>'
-  chat("list").innerHTML = html2
+  chat("main").innerHTML = md.html(html) + '<br></div>'
   chat("left").scrollTop = chat("left").scrollHeight;
-  chat("btnSend").innerHTML = '<b>S</b>end'
+  chat("btnSend").innerHTML = 'Send'
   
-  if (document.body.clientWidth > 800) {
-    chat('prompt').select()
-    chat('prompt').focus();
-  } else {
-    chat('prompt').value = ''
-  }  
+  chat('prompt').value = '';  
 }
 
 // abort fetch request.
@@ -360,35 +347,21 @@ chat.submit = () => {
     chat.abort()
     chat("btnSend").innerText = 'Send'
   } else {
-    chat.stream( chat.prompt = chat('prompt').value )
-    chat("main").innerHTML += '<h4 class=prompt>' + chat.prompt + '</h4>\n<div id=receiving>Receiving....</div>'
+    chat.prompt = chat('prompt').value.trim();
+    if (chat.prompt === '') {
+      chat("message").innerHTML = 'Please input prompt!'
+      return;
+    }
+    chat.stream(chat.prompt);
+    chat("message").innerHTML = 'Receiving messages...';
+    //chat("main").innerHTML += '<h4 class="prompt">' + chat.prompt + '</h4>\n<div id="receiving">Receiving....</div>'
     chat("left").scrollTop = chat("left").scrollHeight;
     chat("btnSend").innerText = 'Stop..'
   }  
 }
 
-/*
-// show default prompt list
-chat.showPrompts = () => {
-  chat('list').innerHTML = chat.prompts
-  document.querySelectorAll('#list li').forEach( (element) => {
-    element.addEventListener('click', (event) => {
-      chat('prompt').value = element.innerText
-      chat('prompt').focus();
-    });
-  })
-};
-*/
-
-chat.clipboard = (i) => {
-  navigator.clipboard.writeText( '### '+ chat.history[i].prompt + '\n\n' + chat.history[i].result )
-  chat("message").innerText = 'dialogue has been copied to clipboard'
-}
-
 // prompt for API key if not found in localStorage
 window.onload = () => {
-  // chat.prompts = chat('list').innerHTML
-  // chat.showPrompts()
   chat('prompt').focus();
 }
 
@@ -400,25 +373,6 @@ document.addEventListener('keydown', function(event) {
     }
   }  
 });
-
-// [20230412] redo. submit latest prompt
-chat.redo = () => {
-  chat.history.pop()
-  chat('prompt').value = chat.prompt
-  chat.submit()
-}
-
-// speak the latest answer
-chat.speak = (i)  => {
-  if (window.speechSynthesis.speaking) {
-     window.speechSynthesis.cancel();
-  } else {
-    i = ( i>=0? i : chat.history.length-1 )
-    const utterance = new SpeechSynthesisUtterance(chat.history[i].result);
-    utterance.rate = 1.5;
-    window.speechSynthesis.speak(utterance);
-  }
-}
 
 // voice recognition
 var SpeechRecognition = SpeechRecognition || webkitSpeechRecognition;


### PR DESCRIPTION
### Description of Changes

Not beautiful, but it's a super simple static-page example of a ChatBot UI.
I started from: https://github.com/casualwriter/vanilla-chatgpt

I'd suggest we do another iteration and try using a real GPT-like UI so it's a but more pleasing to the eye.

Technical details:
- the html page expects a `/chat` POST endpoint (implemented by the OpenAI Chat component)
- I've simplified the JS code to avoid using OpenAI streaming responses for now (just simple HTTP req/resp with the entire message)
- the last 5 prompts/responses are automatically included in the prompt (for conversation context)